### PR TITLE
Updating stockpile wrapper to push a dictionary instead of a string

### DIFF
--- a/stockpile-wrapper/stockpile-wrapper.py
+++ b/stockpile-wrapper/stockpile-wrapper.py
@@ -43,8 +43,8 @@ def _upload_to_es(payload_file,my_uuid,timestamp,es,index):
         try:
             scribe_module = json.loads(scribed)['module']
             _data = { "uuid": my_uuid,
-                            "timestamp": timestamp,
-                            "data": scribed }
+                            "timestamp": timestamp, }
+            _data.update(json.loads(scribed))
             es.index(index=scribe_module+"-metadata", body=_data)
         except Exception as e:
             print(repr(e) + "occurred for the json document:")


### PR DESCRIPTION
Previously we we're pushing a string into elastic. This change along with https://github.com/cloud-bulldozer/scribe/pull/16 will now have it push a dictionary instead.

The old elasticsearch index looked like:
```
{
  "_index": "k8s_namespaces-metadata",
  "_type": "_doc",
  "_id": "Nxld0m4Bs8BI_GhZMDYQ",
  "_version": 1,
  "_score": null,
  "_source": {
    "uuid": "eaed3db9-ca82-4d6d-a285-612bed8ace0e",
    "timestamp": 1575487352,
    "data": "{\n    \"module\": \"k8s_namespaces\",\n    \"source_type\": \"stockpile\",\n    \"host\": \"localhost\",\n    \"scribe_uuid\": \"13f48a30-6a04-4603-ae58-76d5c2ef1694\",\n    \"value\": {\n        \"apiVersion\": \"v1\",\n        \"kind\": \"Namespace\",\n        \"metadata\": {\n            \"creationTimestamp\": \"2019-08-16T16:01:19Z\",\n            \"name\": \"default\",\n            \"resourceVersion\": \"147\",\n            \"selfLink\": \"/api/v1/namespaces/default\",\n            \"uid\": \"c467acb5-1c73-48a7-b98c-834971b8e544\"\n        },\n        \"spec\": {\n            \"finalizers\": [\n                \"kubernetes\"\n            ]\n        },\n        \"status\": {\n            \"phase\": \"Active\"\n        }\n    }\n}"
  },
  "fields": {
    "timestamp": [
      "2019-12-04T19:22:32.000Z"
    ]
  },
  "sort": [
    1575487352000
  ]
}
```

The result in elasticsearch now looks like:
```
{
  "_index": "k8s_configmaps-metadata",
  "_type": "_doc",
  "_id": "VBni-W4Bs8BI_GhZ8T6r",
  "_version": 1,
  "_score": null,
  "_source": {
    "uuid": "2b24e043-4a3a-4bec-986b-802bd42d5c50",
    "timestamp": 1576150426,
    "module": "k8s_configmaps",
    "source_type": "stockpile",
    "host": "localhost",
    "scribe_uuid": "31394ff5-979e-4ad1-b36f-dc7f10d826de",
    "value": {
      "apiVersion": "v1",
      "data": [
        {
          "kubeconfig": "apiVersion: v1\nclusters:\n- cluster:\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQVRBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwdGFXNXAKYTNWaVpVTkJNQjRYRFRFNU1EWXlOREV5TlRFek1Wb1hEVEk1TURZeU1qRXlOVEV6TVZvd0ZURVRNQkVHQTFVRQpBeE1LYldsdWFXdDFZbVZEUVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTVk3CjV4NkJnWHFNRFNHVnBPa1RyUW0zMXpZUytXajFCbmx0VW1mMEQ1dW42dkNJWVdSZGIwQllXQUs1Q2txU3VEa3kKMmdjR0xRQ3Npeis1eDJEYVo5M2ludVQzTXRGVTVTOUJkaERBbnNCSEhuQzRBMC8rVElJTDlKL3hzRDArYW5kVQpMVlkwV0lENnY3ckxDS3VEY0N3Uml2WWZ5Q2NIQUdGOTJGT2c3MnhqaWFBSnFoNHZJdURUTUJ2OVBuL1daQTVUCkdhZlpqWXptQ3BQRnBhaXk3NFI2WmdQVXhhdVE2TStXRmRGWEJUeDFKVEY1ak41WXN2RktaWDR6V3pnSk5Ob3cKNlhQTEdpWkhqTVpsVDZUdCszZzBrNDFvU3FvV2llUGpLM0ErTzFrcG9LWkNWcm44TDgzNkdlc0xvOGJKNU5YZwordCs5NXlTSFlzR09FSHJWSjEwQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUIwR0ExVWRKUVFXCk1CUUdDQ3NHQVFVRkJ3TUNCZ2dyQmdFRkJRY0RBVEFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFCdUc2L2dNT1E1SFdoeUl5UXQrRnNEZS8yOWtsTDYxZjdZUFNVRmd4ZlozYW1EdVNVKwpKMHZXbUZ0VVNzakNxVWJOdUpLSEx3d3JRdHg5dG9xVUluSEZsaGsvQmZpdnVhU0o2Rko4MHd4dktPbEdWVko1Ckt2REk0NC92UmdqUlZuMFpQeHBSL0ZvZnVPMVZUc2x2RkxHcTZDakxlN2NxVkFIM2ZQQ1FHcFZiQ0NIeGMrRUoKRThibCt2akJMY0d0L2J6MytMU1FGVFZHRjVMSjlRQXY3QUp2NWVWQmloUis1QS9QQWNzVituSEI4bkFiektrSwpjMk5ET3dCbUFOUFBXQjJPTzQ5ZHdIVjFBWG1PcElWUlBRa1hZRkhxK3JEY0haR29oZi9ERUZucGhuaWt3K1ZnCmZxbE1JOEQ1NEZ0N0xCOVkzc1BZaUxSclJEZDNmdTRaaDdHbAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\n    server: https://localhost:8443\n  name: \"\"\ncontexts: []\ncurrent-context: \"\"\nkind: Config\npreferences: {}\nusers: []\n"
        }
      ],
      "kind": "ConfigMap",
      "metadata": {
        "creationTimestamp": "2019-08-16T16:01:21Z",
        "name": "cluster-info",
        "namespace": "kube-public",
        "resourceVersion": "318142",
        "selfLink": "/api/v1/namespaces/kube-public/configmaps/cluster-info",
        "uid": "97dd3878-a8e3-4d42-bd8d-dabdffd12596"
      }
    }
  },
  "fields": {
    "timestamp": [
      "2019-12-12T11:33:46.000Z"
    ]
  },
  "sort": [
    1576150426000
  ]
}
```