### PR TITLE
make ceph cache dropper more robust, with better logging

### DIFF
--- a/ceph-cache-dropper/osd-cache-drop-websvc.py
+++ b/ceph-cache-dropper/osd-cache-drop-websvc.py
@@ -8,22 +8,43 @@ import atexit
 import logging
 import cherrypy
 from os import getenv
+from os.path import exists
 
-logging.basicConfig(filename='/tmp/dropcache.log', level=logging.DEBUG)
+# script to watch for changes to monitor list and update
+# comes from RHCS image
+
+toolbox_watch_mons_script = '/usr/local/bin/toolbox.sh'
+
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('dropcache')
-logger.setLevel(logging.INFO)
 
 def flush_log():
     logging.shutdown()
 
 atexit.register(flush_log)
 
+# parse environment variables if present
+
+port_str = getenv("ceph_cache_drop_port")
+if port_str == None:
+    port_str = '9437'
+port = int(port_str)
+logger.info('ceph cache drop port = %d' % port)
+
+cache_drop_timeout = int(getenv('ceph_cache_drop_timeout', '120'))
+logger.info('cache drop timeout = %d sec' % cache_drop_timeout)
+
+
+# implements web server for URL DropOSDCache/
+
 class DropOSDCache(object):
     @cherrypy.expose
     def DropOSDCache(self):
         try:
+            logger.info('received cache drop request')
             result = subprocess.check_output(
-                ["/usr/bin/python3", "/usr/bin/ceph", "tell", "osd.*", "cache", "drop"])
+                ["/usr/bin/python3", "/usr/bin/ceph", "tell", "osd.*", "cache", "drop"], 
+                timeout=cache_drop_timeout)
             logger.info(result)
         except subprocess.CalledProcessError as e:
             logger.error('failed to drop cache')
@@ -35,21 +56,31 @@ class DropOSDCache(object):
     def index(self):
         return 'I am here'
 
-try:
-    result = subprocess.Popen(
-        ["/bin/sh", "-c", "/usr/local/bin/toolbox.sh"])
-except subprocess.CalledProcessError as e:
-    logger.error('failed to source toolbox')
-    logger.exception(e)
-port_str = getenv("ceph_cache_drop_port")
-if port_str == None:
-    port_str = '9437'
-port = int(port_str)
-config = { 
+
+# code to start up CherryPy
+
+def startCherryPy():
+  config = { 
     'global': {
         'server.socket_host': '0.0.0.0' ,
         'server.socket_port': port,
     },
-}
-cherrypy.config.update(config)
-cherrypy.quickstart(DropOSDCache())
+  }
+  cherrypy.config.update(config)
+  cherrypy.quickstart(DropOSDCache())
+
+# keep list of monitors up to date in case monitors ever move
+# this is a best-effort attempt but it might not succeed
+
+if not exists(toolbox_watch_mons_script):
+    logger.warning('cannot react to changes in monitor list')
+
+try:
+    result_fd = subprocess.Popen(
+        ["/bin/sh", "-c", "/usr/local/bin/toolbox.sh"])
+except Exception as e:
+    logger.error('failed to source toolbox')
+    logger.exception(e)
+    sys.exit(1)
+
+startCherryPy()

--- a/kernel_cache_dropper/Dockerfile
+++ b/kernel_cache_dropper/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM fedora:34
 
 RUN dnf install -y --nodocs python3 python3-cherrypy
 RUN ln -s /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
all logging visible with oc logs instead of /tmp/dropcache.log
ceph cache drop command is timed out after 120 sec by default
cache drop timeout is configurable with environment variable
receipt of request is logged before the cache drop attempt occurs
comments added to explain what is going on
all logging is at INFO level so don't bother with DEBUG level

### Description

### Fixes
